### PR TITLE
Update tags (Transfer to rocker-org)

### DIFF
--- a/build/args/r-ver.json
+++ b/build/args/r-ver.json
@@ -4,8 +4,8 @@
 		"variants": {
 			"4.2": {
 				"tags": [
-					"ghcr.io/eitsupi/devcontainer/r-ver:4.2",
-					"ghcr.io/eitsupi/devcontainer/r-ver:4"
+					"ghcr.io/rocker-org/devcontainer/r-ver:4.2",
+					"ghcr.io/rocker-org/devcontainer/r-ver:4"
 				],
 				"platforms": [
 					"linux/amd64",
@@ -14,7 +14,7 @@
 			},
 			"4.1": {
 				"tags": [
-					"ghcr.io/eitsupi/devcontainer/r-ver:4.1"
+					"ghcr.io/rocker-org/devcontainer/r-ver:4.1"
 				],
 				"platforms": [
 					"linux/amd64",
@@ -28,8 +28,8 @@
 		"variants": {
 			"4.2": {
 				"tags": [
-					"ghcr.io/eitsupi/devcontainer/tidyverse:4.2",
-					"ghcr.io/eitsupi/devcontainer/tidyverse:4"
+					"ghcr.io/rocker-org/devcontainer/tidyverse:4.2",
+					"ghcr.io/rocker-org/devcontainer/tidyverse:4"
 				],
 				"platforms": [
 					"linux/amd64"
@@ -37,7 +37,7 @@
 			},
 			"4.1": {
 				"tags": [
-					"ghcr.io/eitsupi/devcontainer/tidyverse:4.1"
+					"ghcr.io/rocker-org/devcontainer/tidyverse:4.1"
 				],
 				"platforms": [
 					"linux/amd64"


### PR DESCRIPTION
@cboettig Do you think the image tags should be something like `ghcr.io/rocker-org/devcontainer/tidyverse:4` for now?

The syntax highlighting looks a little odd because the final slash is part of the image name, but I think it is an easy name to understand.

![image](https://user-images.githubusercontent.com/50911393/189150272-abe76555-96a5-4244-bf0f-31b00d3893ad.png)
