### PR TITLE
Add the `vscDebugger` R package

### DIFF
--- a/src/r-ver/.devcontainer.json
+++ b/src/r-ver/.devcontainer.json
@@ -20,7 +20,8 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"reditorsupport.r"
+				"reditorsupport.r",
+				"RDebugger.r-debugger"
 			],
 			"settings": {
 				"r.rterm.linux": "/usr/local/bin/radian",

--- a/src/r-ver/Dockerfile
+++ b/src/r-ver/Dockerfile
@@ -26,6 +26,7 @@ RUN /rocker_scripts/default_user.sh \
         httpgd \
         languageserver \
     && rm -rf /tmp/downloaded_packages \
-    && strip /usr/local/lib/R/site-library/*/libs/*.so
+    && strip /usr/local/lib/R/site-library/*/libs/*.so \
+    && R -q -e 'remotes::install_github("ManuelHentschel/vscDebugger@*release", dependencies = FALSE)'
 
 COPY --chown=rstudio:rstudio assets/rstudio-prefs.json /home/rstudio/.config/rstudio/


### PR DESCRIPTION
Close  #15

This package must be installed from [the GitHub repo](https://github.com/ManuelHentschel/vscDebugger), and if we try to install it locally using the `remotes` package, the installation often fails due to GitHub API access restrictions.
So it is convenient to have it pre-installed.

Note: We can also use the git cli to install this package without using the GitHub API, but the commands are redundant.

```sh
export TAG=$(git ls-remote --tags --refs --sort='version:refname' https://github.com/ManuelHentschel/vscDebugger v\* | tail -n 1 | cut --delimiter='/' --fields=3) \
    && Rscript -e "remotes::install_git('https://github.com/ManuelHentschel/vscDebugger.git', ref = '"${TAG}"', dependencies = FALSE)"
```