### PR TITLE
Fix rterm path of vscode-R

### DIFF
--- a/src/r-ver/.devcontainer.json
+++ b/src/r-ver/.devcontainer.json
@@ -34,7 +34,7 @@
 		"vscode": {
 			"extensions": ["reditorsupport.r", "RDebugger.r-debugger"],
 			"settings": {
-				"r.rterm.linux": "radian",
+				"r.rterm.linux": "/usr/local/bin/radian",
 				"r.bracketedPaste": true,
 				"r.plot.useHttpgd": true,
 				"[r]": {

--- a/src/rstudio/.devcontainer.json
+++ b/src/rstudio/.devcontainer.json
@@ -34,7 +34,7 @@
 		"vscode": {
 			"extensions": ["reditorsupport.r", "RDebugger.r-debugger"],
 			"settings": {
-				"r.rterm.linux": "radian",
+				"r.rterm.linux": "/usr/local/bin/radian",
 				"r.bracketedPaste": true,
 				"r.plot.useHttpgd": true,
 				"[r]": {


### PR DESCRIPTION
It appears that radian will not detect correctly unless it is set up this way.