### PR TITLE
Add `meta.env` to images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           regex=$(echo '${{ needs.detect-changes.outputs.src }}' | jq '.|join("|")' -r)
           jsoncontent=$(jq -r '{ include: [ .include[] | select(.src_name | test("'${regex}'")) ] } | tostring' ${{ steps.set-json.outputs.json }})
-          echo ::set-output name=matrix::"${jsoncontent}"
+          echo "matrix=${jsoncontent}" >>"${GITHUB_OUTPUT}"
           echo "${jsoncontent}"
 
   build-pr:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Test build
         if: ${{ github.event_name == 'pull_request' }}
         run: |
+          GIT_REPOSITORY="${GITHUB_REPOSITORY}" \
           PLATFORM=linux/amd64 \
           SRC_NAME=${{ matrix.src_name }} \
           IMAGE_NAME=${{ matrix.image_name }} \
@@ -116,6 +117,7 @@ jobs:
         run: npm install -g @devcontainers/cli
       - name: Build and push Docker images
         run: |
+          GIT_REPOSITORY="${GITHUB_REPOSITORY}" \
           SRC_NAME=${{ matrix.src_name }} \
           IMAGE_NAME=${{ matrix.image_name }} \
           VARIANT=${{ matrix.variant }} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
     paths:
+      - Makefile
       - src/**.devcontainer.json
       - src/**Dockerfile
       - src/**/assets/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Test build
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          GIT_REPOSITORY="${GITHUB_REPOSITORY}" \
+          GIT_REPOSITORY="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
           PLATFORM=linux/amd64 \
           SRC_NAME=${{ matrix.src_name }} \
           IMAGE_NAME=${{ matrix.image_name }} \
@@ -118,7 +118,7 @@ jobs:
         run: npm install -g @devcontainers/cli
       - name: Build and push Docker images
         run: |
-          GIT_REPOSITORY="${GITHUB_REPOSITORY}" \
+          GIT_REPOSITORY="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
           SRC_NAME=${{ matrix.src_name }} \
           IMAGE_NAME=${{ matrix.image_name }} \
           VARIANT=${{ matrix.variant }} \


### PR DESCRIPTION
https://github.com/rocker-org/devcontainer-images/issues/6#issuecomment-1356672961

Thanks to devcontainers/features#359, now executing the `devcontainer-info` command in containers can now display the commit id of the source repository (this repository).