### PR TITLE
ci(reports): should ignore `unknown/unknown` platform rows

### DIFF
--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -102,10 +102,11 @@ df_digest <- tryCatch(
     dplyr::filter(!(name == "Name:" & dplyr::lead(name) != "Platform:")) |>
     dplyr::mutate(id = (dplyr::row_number() + 1) %/% 2) |>
     tidyr::pivot_wider(id_cols = id) |>
-    dplyr::select(platform = `Platform:`, RepoDigests = `Name:`),
+    dplyr::select(platform = `Platform:`, RepoDigests = `Name:`) |>
+    dplyr::filter(stringr::str_starts(platform, "linux/")),
   error = function(e) NULL
 )
-if (!is.null(df_digest)) {
+if (!is.null(df_digest) && nrow(df_digest) > 0 && unique(df_digest$platform) > 1) {
   cat(
     "### Platforms\n\n",
     "This image was created by a multi-architecture build. The digests for each platform are as follows."

--- a/build/reports/template.Rmd
+++ b/build/reports/template.Rmd
@@ -106,10 +106,10 @@ df_digest <- tryCatch(
     dplyr::filter(stringr::str_starts(platform, "linux/")),
   error = function(e) NULL
 )
-if (!is.null(df_digest) && nrow(df_digest) > 0 && unique(df_digest$platform) > 1) {
+if (!is.null(df_digest) && nrow(df_digest) > 0) {
   cat(
     "### Platforms\n\n",
-    "This image was created by a multi-architecture build. The digests for each platform are as follows."
+    "The digests for each platform are as follows."
   )
   df_digest |>
     dplyr::mutate(RepoDigests = paste0("`", RepoDigests, "`")) |>


### PR DESCRIPTION
Perhaps due to buildx update, even images that should not be shown are being shown as multi-platform built.

![image](https://user-images.githubusercontent.com/50911393/225641645-c958f485-8ca3-44d8-b6c6-2766f37632b9.png)